### PR TITLE
Make line numbers relative

### DIFF
--- a/src/cmRelLineNumbers.js
+++ b/src/cmRelLineNumbers.js
@@ -1,0 +1,21 @@
+function showRelativeLines(cm) {
+  const lineNum = cm.getCursor().line + 1;
+  if (cm.state.curLineNum === lineNum) {
+    return;
+  }
+  cm.state.curLineNum = lineNum;
+  cm.setOption('lineNumberFormatter', l => 
+    l === lineNum ? lineNum : Math.abs(lineNum - l));
+}
+
+module.exports = {
+	default: function(_context) { 
+		return {
+			plugin: function(CodeMirror) {
+                var editor = document.querySelector(".CodeMirror").CodeMirror;
+                editor.on("cursorActivity", showRelativeLines);
+            },
+			codeMirrorOptions: {'lineNumbers': true},
+		}
+	},
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ joplin.plugins.register({
 	onStart: async function() {
 		await joplin.plugins.registerContentScript(
 			ContentScriptType.CodeMirrorPlugin,
-			'cmLineNumbers',
-			'./cmLineNumbers.js'
+			'cmRelLineNumbers',
+			'./cmRelLineNumbers.js'
 		);
 	},
 });


### PR DESCRIPTION
This makes the displayed line numbers relative to current line.
The current line number will also be displayed.
This is the same behavior as Vim hybrid line numbers (:set number relativenumber).

I find this the most useful when using Vim. 
We could also add a build option to let the user choose between absolute and relative.

reference for implementation:
https://github.com/codemirror/CodeMirror/issues/4116