### PR TITLE
Fix JSON syntax error

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
 	"name": "CodeMirror Line Numbers",
 	"description": "Enables line numbers for CodeMirror editor",
 	"author": "Shantanu Goel",
-	"homepage_url": "https://shantanugoel.com"
+	"homepage_url": "https://shantanugoel.com",
 	"repository_url": "https://github.com/shantanugoel/joplin-plugin-cm-linenumbers",
 	"keywords": []
 }


### PR DESCRIPTION
Avoid SyntaxError during `npm run dist`.